### PR TITLE
Node Selection for cross-filtering

### DIFF
--- a/src/dataInterfaces.ts
+++ b/src/dataInterfaces.ts
@@ -25,6 +25,7 @@
  */
 
 import Node = d3.layout.force.Node;
+import powerbi from "powerbi-visuals-api";
 
 import { TooltipEnabledDataPoint } from "powerbi-visuals-utils-tooltiputils";
 import { valueFormatter as vf } from "powerbi-visuals-utils-formattingutils";
@@ -41,6 +42,7 @@ export interface ForceGraphNode extends Node {
     isDrag?: boolean;
     isOver?: boolean;
     hideLabel?: boolean;
+    identity: powerbi.visuals.ISelectionId;
 }
 
 export interface ITextRect {

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -125,7 +125,7 @@ export class ForceGraph implements IVisual {
         width: 24,
         height: 24
     };
-    
+
     private static ImagePosition: number = -12;
     private static MinNodeWeight: number = 5;
     private static MinCharge: number = -100;
@@ -203,7 +203,7 @@ export class ForceGraph implements IVisual {
         this.marginValue = { ...value };
         this.viewportInValue = ForceGraph.substractMargin(this.viewport, this.margin);
     }
-    
+
     private viewportValue: IViewport;
 
     private get viewport(): IViewport {
@@ -369,7 +369,7 @@ export class ForceGraph implements IVisual {
         ) {
             return null;
         }
-        
+
         let sourceCategories: any[] = categorical.Source.values,
             targetCategories: any[] = categorical.Target.values,
             sourceTypeCategories: any[] = (categorical.SourceType || { values: [] }).values,
@@ -400,7 +400,7 @@ export class ForceGraph implements IVisual {
         let targetFormatter: IValueFormatter = valueFormatter.create({
             format: valueFormatter.getFormatStringByColumn(metadata.Target, true),
         });
-        
+
         for (let i = 0; i < targetCategories.length; i++) {
             const source = sourceCategories[i];
             const target = targetCategories[i];
@@ -421,7 +421,7 @@ export class ForceGraph implements IVisual {
                         .withCategory(categorical.Source, i)
                         .withMeasure(<string>categorical.Source.values[i])
                         .createSelectionId()
-                }
+                };
             }
 
             if (!nodes[target]) {
@@ -433,8 +433,8 @@ export class ForceGraph implements IVisual {
                     identity: host.createSelectionIdBuilder()
                         .withCategory(categorical.Target, i)
                         .withMeasure(<string>categorical.Target.values[i])
-                        .createSelectionId() 
-                }
+                        .createSelectionId()
+                };
             }
 
             let sourceNode: ForceGraphNode = nodes[source],
@@ -717,9 +717,8 @@ export class ForceGraph implements IVisual {
                 node.isOver = false;
                 this.fadeNode(node);
             })
-            .on("click", function(d) {
-                selectionManager.select(d.identity).then((ids: ISelectionId[]) => {
-                }); 
+            .on("click", function (d) {
+                selectionManager.select(d.identity);
 
                 (<Event>d3.event).stopPropagation();
             });

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -108,9 +108,6 @@ import ISelectionManager = powerbi.extensibility.ISelectionManager;
 import IVisualHost = powerbi.extensibility.visual.IVisualHost;
 import ISelectionId = powerbi.extensibility.ISelectionId;
 
-import { hostname } from "os";
-
-
 export class ForceGraph implements IVisual {
 
     private static Count: number = 0;
@@ -139,10 +136,10 @@ export class ForceGraph implements IVisual {
     private static LinkDistance: number = 100;
     private static HoverOpacity: number = 0.3;
     private static DefaultOpacity: number = 1;
-    private static DefaultLinkColor: string = "#ccc";
+    private static DefaultLinkColor: string = "#bbb";
     private static DefaultLinkHighlightColor: string = "#f00";
     private static DefaultLinkThickness: string = "1.5px";
-    private static LabelsFontFamily: string = "sans serif";
+    private static LabelsFontFamily: string = "sans-serif";
     private static MinRangeValue: number = 1;
     private static MaxRangeValue: number = 10;
     private static DefaultValueOfExistingLink: number = 1;
@@ -417,6 +414,7 @@ export class ForceGraph implements IVisual {
             if (!nodes[source]) {
                 nodes[source] = {
                     name: sourceFormatter.format(source),
+                    hideLabel: false,
                     image: sourceType || ForceGraph.DefaultSourceType,
                     adj: {},
                     identity: host.createSelectionIdBuilder()
@@ -719,8 +717,7 @@ export class ForceGraph implements IVisual {
                 node.isOver = false;
                 this.fadeNode(node);
             })
-            
-            .on('click', function(d) {
+            .on("click", function(d) {
                 selectionManager.select(d.identity).then((ids: ISelectionId[]) => {
                 }); 
 


### PR DESCRIPTION
Adding a SelectionID to each Node so clicking on a node cross filters other PBI visuals
This makes the ForceGraph more interesting and interactive, beyond just the visual layout.

Notes:
In DataInterfaces.ts, added the identity property to the ForceGraphNode for each node's selectionID
In Visual.ts, created a SelectionManager to store all selectionIDs and created them using the SelectionIdBuilder, storing them in the identity property. Clicking on the node selects that identity / SelectionID, PowerBI does the rest. The filter key includes the Category (data table) and the first Measure.